### PR TITLE
update harbor conformance test workflow

### DIFF
--- a/.github/workflows/harbor_1.yml
+++ b/.github/workflows/harbor_1.yml
@@ -11,13 +11,30 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - name: checkout Harobr
+        uses: actions/checkout@master
+        with:
+          repository: goharbor/harbor
+      - name: install harbor
+        run: |
+          IP=`hostname -I | awk '{print $1}'`
+          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
+          sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
+          sudo make install
+          timeout 200 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1/api/v2.0/systeminfo)" != "200" ]]; do sleep 5; done' || false
       - name: Run OCI Distribution Spec conformance tests
         uses: opencontainers/distribution-spec@master
         env:
-          OCI_ROOT_URL: https://demo.goharbor.io
+          OCI_ROOT_URL: ${{ env.OCI_ROOT_URL }}
           OCI_USERNAME: ${{ secrets.HARBOR_USERNAME }}
           OCI_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
-          OCI_NAMESPACE: oci-conformance/distribution-test
+          OCI_NAMESPACE: library/oci-conformance
           OCI_TEST_PULL: 1
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
       - name: Upload test report to S3

--- a/.github/workflows/harbor_2.yml
+++ b/.github/workflows/harbor_2.yml
@@ -11,13 +11,30 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - name: checkout Harobr
+        uses: actions/checkout@master
+        with:
+          repository: goharbor/harbor
+      - name: install harbor
+        run: |
+          IP=`hostname -I | awk '{print $1}'`
+          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
+          sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
+          sudo make install
+          timeout 200 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1/api/v2.0/systeminfo)" != "200" ]]; do sleep 5; done' || false
       - name: Run OCI Distribution Spec conformance tests
         uses: opencontainers/distribution-spec@master
         env:
-          OCI_ROOT_URL: https://demo.goharbor.io
+          OCI_ROOT_URL: ${{ env.OCI_ROOT_URL }}
           OCI_USERNAME: ${{ secrets.HARBOR_USERNAME }}
           OCI_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
-          OCI_NAMESPACE: oci-conformance/distribution-test
+          OCI_NAMESPACE: library/oci-conformance
           OCI_TEST_PUSH: 1
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
       - name: Upload test report to S3

--- a/.github/workflows/harbor_3.yml
+++ b/.github/workflows/harbor_3.yml
@@ -11,13 +11,30 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - name: checkout Harobr
+        uses: actions/checkout@master
+        with:
+          repository: goharbor/harbor
+      - name: install harbor
+        run: |
+          IP=`hostname -I | awk '{print $1}'`
+          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
+          sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
+          sudo make install
+          timeout 200 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1/api/v2.0/systeminfo)" != "200" ]]; do sleep 5; done' || false
       - name: Run OCI Distribution Spec conformance tests
         uses: opencontainers/distribution-spec@master
         env:
-          OCI_ROOT_URL: https://demo.goharbor.io
+          OCI_ROOT_URL: ${{ env.OCI_ROOT_URL }}
           OCI_USERNAME: ${{ secrets.HARBOR_USERNAME }}
           OCI_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
-          OCI_NAMESPACE: oci-conformance/distribution-test
+          OCI_NAMESPACE: library/oci-conformance
           OCI_TEST_CONTENT_DISCOVERY: 1
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
       - name: Upload test report to S3

--- a/.github/workflows/harbor_4.yml
+++ b/.github/workflows/harbor_4.yml
@@ -11,13 +11,30 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - name: checkout Harobr
+        uses: actions/checkout@master
+        with:
+          repository: goharbor/harbor
+      - name: install harbor
+        run: |
+          IP=`hostname -I | awk '{print $1}'`
+          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
+          sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
+          sudo make install
+          timeout 200 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1/api/v2.0/systeminfo)" != "200" ]]; do sleep 5; done' || false
       - name: Run OCI Distribution Spec conformance tests
         uses: opencontainers/distribution-spec@master
         env:
-          OCI_ROOT_URL: https://demo.goharbor.io
+          OCI_ROOT_URL: ${{ env.OCI_ROOT_URL }}
           OCI_USERNAME: ${{ secrets.HARBOR_USERNAME }}
           OCI_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
-          OCI_NAMESPACE: oci-conformance/distribution-test
+          OCI_NAMESPACE: library/oci-conformance
           OCI_TEST_CONTENT_MANAGEMENT: 1
           OCI_HIDE_SKIPPED_WORKFLOWS: 1
       - name: Upload test report to S3


### PR DESCRIPTION
Revise the flow to test the latest master code rather than the demo site, as the demo site is not
stable enough, the testing namespace can be removed by any of player.

Also, the demo site is a fixed build, the fix of conformance test failuse will only be in the master code.

The flow is built for http as the conformance-test docker image has no way to inject the self-signed crt,
which created in the phase of install Harbor.

Signed-off-by: wang yan <wangyan@vmware.com>