### PR TITLE
Replace github actions deprecated "set-env"

### DIFF
--- a/.github/workflows/distribution_1.yml
+++ b/.github/workflows/distribution_1.yml
@@ -30,7 +30,7 @@ jobs:
           cp main/.github/config/distribution.yml distribution/
           cd ./distribution
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:5000"
+          echo "OCI_ROOT_URL=http://${IP}:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -t "${DISTRIBUTION_REF}" .
           docker run --rm -p 5000:5000 -v "$(pwd)/distribution.yml":/etc/docker/registry/config.yml -idt "${DISTRIBUTION_REF}"

--- a/.github/workflows/distribution_2.yml
+++ b/.github/workflows/distribution_2.yml
@@ -30,7 +30,7 @@ jobs:
           cp main/.github/config/distribution.yml distribution/
           cd ./distribution
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:5000"
+          echo "OCI_ROOT_URL=http://${IP}:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -t "${DISTRIBUTION_REF}" .
           docker run --rm -p 5000:5000 -v "$(pwd)/distribution.yml":/etc/docker/registry/config.yml -idt "${DISTRIBUTION_REF}"

--- a/.github/workflows/distribution_3.yml
+++ b/.github/workflows/distribution_3.yml
@@ -30,7 +30,7 @@ jobs:
           cp main/.github/config/distribution.yml distribution/
           cd ./distribution
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:5000"
+          echo "OCI_ROOT_URL=http://${IP}:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -t "${DISTRIBUTION_REF}" .
           docker run --rm -p 5000:5000 -v "$(pwd)/distribution.yml":/etc/docker/registry/config.yml -idt "${DISTRIBUTION_REF}"

--- a/.github/workflows/distribution_4.yml
+++ b/.github/workflows/distribution_4.yml
@@ -30,7 +30,7 @@ jobs:
           cp main/.github/config/distribution.yml distribution/
           cd ./distribution
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:5000"
+          echo "OCI_ROOT_URL=http://${IP}:5000" >> $GITHUB_ENV
           DISTRIBUTION_REF="local-distribution:v$(date +%Y%m%d%H%M%S)"
           docker build -t "${DISTRIBUTION_REF}" .
           docker run --rm -p 5000:5000 -v "$(pwd)/distribution.yml":/etc/docker/registry/config.yml -idt "${DISTRIBUTION_REF}"

--- a/.github/workflows/harbor_1.yml
+++ b/.github/workflows/harbor_1.yml
@@ -23,7 +23,7 @@ jobs:
       - name: install harbor
         run: |
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          echo "OCI_ROOT_URL=http://${IP}" >> $GITHUB_ENV
           sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
           sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
           sudo make install

--- a/.github/workflows/harbor_2.yml
+++ b/.github/workflows/harbor_2.yml
@@ -23,7 +23,7 @@ jobs:
       - name: install harbor
         run: |
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          echo "OCI_ROOT_URL=http://${IP}" >> $GITHUB_ENV
           sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
           sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
           sudo make install

--- a/.github/workflows/harbor_3.yml
+++ b/.github/workflows/harbor_3.yml
@@ -23,7 +23,7 @@ jobs:
       - name: install harbor
         run: |
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          echo "OCI_ROOT_URL=http://${IP}" >> $GITHUB_ENV
           sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
           sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
           sudo make install

--- a/.github/workflows/harbor_4.yml
+++ b/.github/workflows/harbor_4.yml
@@ -23,7 +23,7 @@ jobs:
       - name: install harbor
         run: |
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=OCI_ROOT_URL::http://$IP"
+          echo "OCI_ROOT_URL=http://${IP}" >> $GITHUB_ENV
           sudo sed "s/reg.mydomain.com/$IP/" make/harbor.yml.tmpl |sudo tee make/harbor.yml
           sudo sed "s|https:|#https:|g; s|port: 443|#port: 443|g; s|certificate: /your/certificate/path|#certificate: /your/certificate/path|g; s|private_key: /your/private/key/path|#private_key: /your/private/key/path|g" -i make/harbor.yml
           sudo make install

--- a/.github/workflows/trow_1.yml
+++ b/.github/workflows/trow_1.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cd ./trow
           IP="$(hostname -I | awk '{print $1}')"
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:8000"
+          echo "OCI_ROOT_URL=http://${IP}:8000" >> $GITHUB_ENV
           TROW_REF="local-trow:v$(date +%Y%m%d%H%M%S)"
           docker build -f docker/Dockerfile -t "${TROW_REF}" .
           docker run --rm -d -p 8000:8000 "${TROW_REF}" --no-tls

--- a/.github/workflows/trow_2.yml
+++ b/.github/workflows/trow_2.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cd ./trow
           IP="$(hostname -I | awk '{print $1}')"
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:8000"
+          echo "OCI_ROOT_URL=http://${IP}:8000" >> $GITHUB_ENV
           TROW_REF="local-trow:v$(date +%Y%m%d%H%M%S)"
           docker build -f docker/Dockerfile -t "${TROW_REF}" .
           docker run --rm -d -p 8000:8000 "${TROW_REF}" --no-tls

--- a/.github/workflows/trow_3.yml
+++ b/.github/workflows/trow_3.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cd ./trow
           IP="$(hostname -I | awk '{print $1}')"
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:8000"
+          echo "OCI_ROOT_URL=http://${IP}:8000" >> $GITHUB_ENV
           TROW_REF="local-trow:v$(date +%Y%m%d%H%M%S)"
           docker build -f docker/Dockerfile -t "${TROW_REF}" .
           docker run --rm -d -p 8000:8000 "${TROW_REF}" --no-tls

--- a/.github/workflows/trow_4.yml
+++ b/.github/workflows/trow_4.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cd ./trow
           IP="$(hostname -I | awk '{print $1}')"
-          echo "::set-env name=OCI_ROOT_URL::http://${IP}:8000"
+          echo "OCI_ROOT_URL=http://${IP}:8000" >> $GITHUB_ENV
           TROW_REF="local-trow:v$(date +%Y%m%d%H%M%S)"
           docker build -f docker/Dockerfile -t "${TROW_REF}" .
           docker run --rm -d -p 8000:8000 "${TROW_REF}" --no-tls


### PR DESCRIPTION
GitHub Actions at some point deprecated the "set-env" method we were using to persist environment variables from one step to the next. This is a fix based on how Zot workflows are working.