### PR TITLE
Fix for AWS CLI deprecated "ecr get-login"

### DIFF
--- a/.github/workflows/ecr_1.yml
+++ b/.github/workflows/ecr_1.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login --no-include-email | awk '{print $6}')"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
-          echo "::set-env name=ECR_ACCESS_TOKEN::${ECR_ACCESS_TOKEN}"
+          echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ECR_ACCESS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ECR_ACCESS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ecr_2.yml
+++ b/.github/workflows/ecr_2.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login --no-include-email | awk '{print $6}')"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
-          echo "::set-env name=ECR_ACCESS_TOKEN::${ECR_ACCESS_TOKEN}"
+          echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ECR_ACCESS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ECR_ACCESS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ecr_3.yml
+++ b/.github/workflows/ecr_3.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login --no-include-email | awk '{print $6}')"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
-          echo "::set-env name=ECR_ACCESS_TOKEN::${ECR_ACCESS_TOKEN}"
+          echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ECR_ACCESS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ECR_ACCESS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ecr_4.yml
+++ b/.github/workflows/ecr_4.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login --no-include-email | awk '{print $6}')"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
-          echo "::set-env name=ECR_ACCESS_TOKEN::${ECR_ACCESS_TOKEN}"
+          echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ECR_ACCESS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ECR_ACCESS_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
At some point, AWS CLI deprecated the `ecr get-login` command. This change uses the new `ecr get-get-authorization-token`, and also adds fixes for deprecated GitHub Actions syntax as in #72