### PR TITLE
AWS: use get-login-password vs. get-authorization-token

### DIFF
--- a/.github/workflows/ecr_1.yml
+++ b/.github/workflows/ecr_1.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login-password)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
           echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ecr_2.yml
+++ b/.github/workflows/ecr_2.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login-password)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
           echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ecr_3.yml
+++ b/.github/workflows/ecr_3.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login-password)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
           echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ecr_4.yml
+++ b/.github/workflows/ecr_4.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Generate Amazon access token
         run: |
-          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-authorization-token | jq -r .authorizationData[0].authorizationToken)"
+          export ECR_ACCESS_TOKEN="$(aws --region=us-east-1 ecr get-login-password)"
           echo "::add-mask::${ECR_ACCESS_TOKEN}"
           echo "ECR_ACCESS_TOKEN=${ECR_ACCESS_TOKEN}" >> $GITHUB_ENV
         env:


### PR DESCRIPTION
Turns out #73 was incorrect. That token is the base64-encoded version of `AWS:<token>`. This simplifies getting the token.

cc @samuelkarp