### PR TITLE
Adding jForg Artifactory OCI Conformance Test Results

### DIFF
--- a/distribution-spec/v1.0/artifactory/PRODUCT.yaml
+++ b/distribution-spec/v1.0/artifactory/PRODUCT.yaml
@@ -1,0 +1,18 @@
+vendor: jFrog
+name: Artifactory
+version: 7.61.0
+website_url: https://github.com/sapcc/keppel
+documentation_url: https://jfrog.com/help/r/jfrog-artifactory-documentation
+product_logo_url: https://media.jfrog.com/wp-content/uploads/2022/05/24134044/artifactory-Icon.png
+type: cloud and self hosted
+description: Artifactory provides universal management of binaries, packages, & dependencies including OCI artifacts.
+  
+  
+  export OCI_ROOT_URL=https://jade123.jfrog.io
+  export OCI_USERNAME=teceba7658@raotus.com
+  export OCI_PASSWORD=M@xmem0ry!
+  export OCI_NAMESPACE=oci-local
+  export OCI_TEST_PULL=1
+  export OCI_TEST_PUSH=1
+  export OCI_TEST_CONTENT_DISCOVERY=1
+  export OCI_TEST_CONTENT_MANAGEMENT=1

--- a/distribution-spec/v1.0/artifactory/README.md
+++ b/distribution-spec/v1.0/artifactory/README.md
@@ -1,0 +1,47 @@
+![Artifactory Logo](https://media.jfrog.com/wp-content/uploads/2022/05/24134044/artifactory-Icon.png)
+# jFrog Artifactory
+
+
+
+### Get Artifactory
+#### * Try out Artifactory - start [here](https://jfrog.com/start-free/)
+#### * Create a local OCI repository called oci-local
+
+```bash
+docker login <artifactory-url>
+```
+---
+
+## Run the conformance test
+
+---
+
+
+#### Clone OCI Distribution Spec
+
+```bash
+git clone https://github.com/opencontainers/distribution-spec
+```
+
+#### Build conformance binary
+```bash
+cd distribution-spec/conformance
+go test -c
+```
+
+#### Set various environment variables
+```bash
+export OCI_ROOT_URL=<artifactory-url>
+export OCI_USERNAME=<artifactory-user>
+export OCI_PASSWORD=<artifactory-token>
+export OCI_NAMESPACE=oci-local
+export OCI_TEST_PULL=1
+export OCI_TEST_PUSH=1
+export OCI_TEST_CONTENT_DISCOVERY=1
+export OCI_TEST_CONTENT_MANAGEMENT=1
+```
+
+#### Run conformance test
+```bash
+./conformance.test
+```

--- a/distribution-spec/v1.0/artifactory/junit.xml
+++ b/distribution-spec/v1.0/artifactory/junit.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite name="OCI Distribution Conformance Tests" tests="60" failures="3" errors="0" time="1.332">
+      <testcase name="OCI Distribution Conformance Tests Pull Setup Populate registry with test blob" classname="OCI Distribution Conformance Tests" time="0.226828041"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Setup Populate registry with test layer" classname="OCI Distribution Conformance Tests" time="0.021282167"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Setup Populate registry with test manifest" classname="OCI Distribution Conformance Tests" time="0.082733917"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Setup Get the name of a tag" classname="OCI Distribution Conformance Tests" time="0.071250875"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Setup Get tag name from environment" classname="OCI Distribution Conformance Tests" time="0.00069675">
+          <skipped>/Users/idanso/oci-conformance/distribution-spec/conformance/01_pull_test.go:87&#xA;you have skipped this test.&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/setup.go:353</skipped>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull blobs HEAD request to nonexistent blob should result in 404 response" classname="OCI Distribution Conformance Tests" time="0.030214416"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull blobs HEAD request to existing blob should yield 200" classname="OCI Distribution Conformance Tests" time="0.007253917"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull blobs GET nonexistent blob should result in 404 response" classname="OCI Distribution Conformance Tests" time="0.015523625"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull blobs GET request to existing blob URL should yield 200" classname="OCI Distribution Conformance Tests" time="0.027845417"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull manifests HEAD request to nonexistent manifest should return 404" classname="OCI Distribution Conformance Tests" time="0.008596"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull manifests HEAD request to manifest path (digest) should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.015763667"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull manifests HEAD request to manifest path (tag) should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.010121"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull manifests GET nonexistent manifest should return 404" classname="OCI Distribution Conformance Tests" time="0.006386417"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull manifests GET request to manifest path (digest) should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.007970583"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Pull manifests GET request to manifest path (tag) should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.007392541"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Error codes 400 response body should contain OCI-conforming JSON message" classname="OCI Distribution Conformance Tests" time="0.008567875"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Teardown Delete config blob created in setup" classname="OCI Distribution Conformance Tests" time="0.012413"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Teardown Delete layer blob created in setup" classname="OCI Distribution Conformance Tests" time="0.004507375"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Pull Teardown Delete manifest created in setup" classname="OCI Distribution Conformance Tests" time="0.031906875"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Streamed PATCH request with blob in body should yield 202 response" classname="OCI Distribution Conformance Tests" time="0.042819458"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Streamed PUT request to session URL with digest should yield 201 response" classname="OCI Distribution Conformance Tests" time="0.019385583"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic GET nonexistent blob should result in 404 response" classname="OCI Distribution Conformance Tests" time="0.010184208"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic POST request with digest and blob should yield a 201 or 202" classname="OCI Distribution Conformance Tests" time="0.009762"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic GET request to blob URL from prior request should yield 200 or 404 based on response code" classname="OCI Distribution Conformance Tests" time="0.008857792"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic POST request should yield a session ID" classname="OCI Distribution Conformance Tests" time="0.0087195"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic PUT upload of a blob should yield a 201 Response" classname="OCI Distribution Conformance Tests" time="0.012283958"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic GET request to existing blob should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.005933458">
+          <failure type="Failure">/Users/idanso/oci-conformance/distribution-spec/conformance/02_push_test.go:116&#xA;Expected&#xA;    &lt;int&gt;: 404&#xA;to equal&#xA;    &lt;int&gt;: 200&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/02_push_test.go:121</failure>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic PUT upload of a layer blob should yield a 201 Response" classname="OCI Distribution Conformance Tests" time="0.015312208"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Monolithic GET request to existing layer should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.005256708">
+          <failure type="Failure">/Users/idanso/oci-conformance/distribution-spec/conformance/02_push_test.go:141&#xA;Expected&#xA;    &lt;int&gt;: 404&#xA;to equal&#xA;    &lt;int&gt;: 200&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/02_push_test.go:146</failure>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Chunked Out-of-order blob upload should return 416" classname="OCI Distribution Conformance Tests" time="0.010038041"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Chunked PATCH request with first chunk should return 202" classname="OCI Distribution Conformance Tests" time="0.014119375"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Blob Upload Chunked PUT request with final chunk should return 201" classname="OCI Distribution Conformance Tests" time="0.011553333"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Cross-Repository Blob Mount Cross-mounting of a blob without the from argument should yield session id" classname="OCI Distribution Conformance Tests" time="0.006629708"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Cross-Repository Blob Mount POST request to mount another repository&#39;s blob should return 201 or 202" classname="OCI Distribution Conformance Tests" time="0.008297792"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Cross-Repository Blob Mount GET request to test digest within cross-mount namespace should return 200" classname="OCI Distribution Conformance Tests" time="0.000125125">
+          <skipped>/Users/idanso/oci-conformance/distribution-spec/conformance/02_push_test.go:235&#xA;you have skipped this test.&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/setup.go:347</skipped>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Cross-Repository Blob Mount Cross-mounting of nonexistent blob should yield session id" classname="OCI Distribution Conformance Tests" time="2.5e-06"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Cross-Repository Blob Mount Cross-mounting without from, and automatic content discovery enabled should return a 201" classname="OCI Distribution Conformance Tests" time="0.00010225">
+          <skipped>/Users/idanso/oci-conformance/distribution-spec/conformance/02_push_test.go:253&#xA;you have skipped this test.&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/setup.go:347</skipped>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Cross-Repository Blob Mount Cross-mounting without from, and automatic content discovery disabled should return a 202" classname="OCI Distribution Conformance Tests" time="9.6458e-05">
+          <skipped>/Users/idanso/oci-conformance/distribution-spec/conformance/02_push_test.go:267&#xA;you have skipped this test.&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/setup.go:347</skipped>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Manifest Upload GET nonexistent manifest should return 404" classname="OCI Distribution Conformance Tests" time="0.005405625"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Manifest Upload PUT should accept a manifest upload" classname="OCI Distribution Conformance Tests" time="0.091841916"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Manifest Upload Registry should accept a manifest upload with no layers" classname="OCI Distribution Conformance Tests" time="0.023386042"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Manifest Upload GET request to manifest URL (digest) should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.009409459"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Teardown Delete config blob created in tests" classname="OCI Distribution Conformance Tests" time="0.004352417"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Teardown Delete layer blob created in setup" classname="OCI Distribution Conformance Tests" time="0.003590333"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Push Teardown Delete manifest created in tests" classname="OCI Distribution Conformance Tests" time="0.055349958"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Setup Populate registry with test blob" classname="OCI Distribution Conformance Tests" time="0.020780583"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Setup Populate registry with test layer" classname="OCI Distribution Conformance Tests" time="0.020031167"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Setup Populate registry with test tags" classname="OCI Distribution Conformance Tests" time="0.099194125"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Setup Populate registry with test tags (no push)" classname="OCI Distribution Conformance Tests" time="0.000131458">
+          <skipped>/Users/idanso/oci-conformance/distribution-spec/conformance/03_discovery_test.go:80&#xA;you have skipped this test.&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/setup.go:353</skipped>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Test content discovery endpoints GET request to list tags should yield 200 response" classname="OCI Distribution Conformance Tests" time="0.005305"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Test content discovery endpoints GET number of tags should be limitable by `n` query parameter" classname="OCI Distribution Conformance Tests" time="0.0058355"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Test content discovery endpoints GET start of tag is set by `last` query parameter" classname="OCI Distribution Conformance Tests" time="0.015011"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Teardown Delete config blob created in tests" classname="OCI Distribution Conformance Tests" time="0.005759792"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Teardown Delete layer blob created in setup" classname="OCI Distribution Conformance Tests" time="0.003949"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Discovery Teardown Delete created manifest &amp; associated tags" classname="OCI Distribution Conformance Tests" time="0.057194209"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Setup Populate registry with test config blob" classname="OCI Distribution Conformance Tests" time="0.019048708"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Setup Populate registry with test layer" classname="OCI Distribution Conformance Tests" time="0.015869292"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Setup Populate registry with test tag" classname="OCI Distribution Conformance Tests" time="0.02254625"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Setup Check how many tags there are before anything gets deleted" classname="OCI Distribution Conformance Tests" time="0.008524709"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Manifest delete DELETE request to manifest tag should return 202, unless tag deletion is disallowed (400/405)" classname="OCI Distribution Conformance Tests" time="0.01841675"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Manifest delete DELETE request to manifest (digest) should yield 202 response unless already deleted" classname="OCI Distribution Conformance Tests" time="0.006927667"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Manifest delete GET request to deleted manifest URL should yield 404 response, unless delete is disallowed" classname="OCI Distribution Conformance Tests" time="0.006154708"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Manifest delete GET request to tags list should reflect manifest deletion" classname="OCI Distribution Conformance Tests" time="0.008977208"></testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Blob delete DELETE request to blob URL should yield 202 response" classname="OCI Distribution Conformance Tests" time="0.004368458">
+          <failure type="Failure">/Users/idanso/oci-conformance/distribution-spec/conformance/04_management_test.go:143&#xA;Expected&#xA;    &lt;int&gt;: 405&#xA;to equal&#xA;    &lt;int&gt;: 202&#xA;/Users/idanso/oci-conformance/distribution-spec/conformance/04_management_test.go:150</failure>
+      </testcase>
+      <testcase name="OCI Distribution Conformance Tests Content Management Blob delete GET request to deleted blob URL should yield 404 response" classname="OCI Distribution Conformance Tests" time="0.005398833"></testcase>
+  </testsuite>

--- a/distribution-spec/v1.0/artifactory/report.html
+++ b/distribution-spec/v1.0/artifactory/report.html
@@ -1,0 +1,6308 @@
+<html>
+  <head>
+    <title>OCI Distribution Conformance Tests</title>
+    <style>
+      body {
+        padding: 10px 20px 10px 20px;
+        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,PingFang SC,Hiragino Sans GB,Microsoft YaHei,Helvetica Neue,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+        background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAG0lEQVQYV2Pce7zwv7NlPyMDFMAZGAIwlRgqAFydCAVv5m4UAAAAAElFTkSuQmCC") repeat;
+         
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+        background-color: white;
+      }
+      th, td {
+        padding: 12px;
+        text-align: left;
+        border-bottom: 1px solid #ddd;
+      }
+      tr:hover {
+        background-color: #ffe39b;
+      }
+      .result {
+        padding: 1.25em 0 .25em 0.8em;
+        border: 1px solid #e1e1e1;
+        border-radius: 5px;
+        margin-top: 10px;
+      }
+      .red {
+        background: #ffc8c8;
+      }
+      pre.fail-message {
+        background: #f9a5a5;
+        padding: 20px;
+        margin-right: 10px;
+        display: inline-block;
+        border-radius: 4px;
+        font-size: 1.25em;
+        width: 94%;
+        overflow-x: auto;
+        max-width: 85%;
+      }
+      .green {
+        background: #c8ffc8;
+        padding: 1.25em 0 1.25em 0.8em;
+      }
+      .grey {
+        background: lightgrey;
+        padding: 1.25em 0 1.25em 0.8em;
+      }
+      .toggle {
+        border: 2px solid #3e3e3e;
+        cursor: pointer;
+        width: 1em;
+        text-align: center;
+        font-weight: bold;
+        display: inline;
+        font-family: monospace;
+        padding: 0 .25em 0 .25em;
+        margin: 1em 1em 1em 0;
+        font-size: 12pt;
+        color: #3e3e3e;
+        border-radius: 3px;
+      }
+      pre.pre-box {
+        background: #343a40;
+        color: #fff;
+        padding: 10px;
+        border: 1px solid gray;
+        display: inline-block;
+        border-radius: 4px;
+        width: 97%;
+        font-size: 1.25em;
+        overflow-x: auto;
+        max-height: 60em;
+        overflow-y: auto;
+        max-width: 85%;
+      }
+      .summary {
+        width: 100%;
+        height: auto;
+        padding: 0 0 .5em 0;
+        border-radius: 6px;
+        border: 1px solid #cccddd;
+        background: white;
+      }
+      .summary-bullet {
+        width: 100%;
+        height: auto;
+        display: flex;
+        flex-wrap: wrap;
+        padding: .5em .1em .1em .5em;
+      }
+      .bullet-left {
+        width: 25%;
+        font-weight: bold;
+        font-size: 100%;
+      }
+      .bullet-right {
+        width: auto;
+        font-family: monospace;
+        font-size: 110%;
+      }
+      .quick-summary {
+        width: 70%;
+        display: flex;
+        margin: 0 auto 0 0;
+        font-weight: bold;
+        font-size: 1.2em;
+      }
+      .darkgreen {
+        color: green;
+      }
+      .darkred {
+        color: red;
+        padding: 0 0 0 2em;
+      }
+      .darkgrey {
+        color: grey;
+        padding: 0 0 0 2em;
+      }
+      .meter {
+        border: 1px solid black;
+        margin: 0 .5em 0 auto;
+        display: flex;
+        height: 25px;
+        width: 45%;
+      }
+      @media only screen and (max-width: 600px) {
+        .meter {
+          display: none;
+        }
+      }
+      .meter-green {
+        height: 100%;
+        background: green;
+        width: 88%;
+      }
+      .meter-red {
+        height: 100%;
+        background: red;
+        width: 5%;
+      }
+      .meter-grey {
+        height: 100%;
+        background: grey;
+        width: 8%;
+      }
+      .subcategory {
+        background: white;
+        padding: 0px 20px 20px 20px;
+        border: 1px solid #cccddd;
+        border-radius: 6px;
+      }
+      h2 {
+        margin-top: 45px;
+      }
+      h4 {
+        vertical-align: bottom;
+        cursor: pointer;
+      }
+    </style>
+    <script>
+      function toggleOutput(id) {
+        var elem = document.getElementById(id);
+        var button = document.getElementById(id + "-button");
+        if (elem.style['display'] === 'block') {
+          button.innerHTML = "+";
+          elem.style['display'] = 'none';
+        } else {
+          button.innerHTML = "-";
+          elem.style['display'] = 'block';
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <h1>OCI Distribution Conformance Tests</h1>
+    <table>
+      <tr>
+      </tr>
+      <tr>
+        <td class="bullet-left">Summary</td>
+        <td>
+          <div class="quick-summary"><span class="darkgreen">57 passed</span><span class="darkred">3 failed</span><span class="darkgrey">5 skipped</span><div class="meter">
+              <div class="meter-green"></div>
+              <div class="meter-red"></div>
+              <div class="meter-grey"></div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="bullet-left">Start Time</td>
+        <td>Apr 4 16:24:07.661 &#43;0300 IDT</td>
+      </tr>
+      <tr>
+        <td class="bullet-left">End Time</td>
+        <td>Apr 4 16:24:08.994 &#43;0300 IDT</td>
+      </tr>
+      <tr>
+        <td class="bullet-left">Time Elapsed</td>
+        <td>1.3326985s</td>
+      </tr>
+      <tr>
+        <td class="bullet-left">Test Version</td>
+        <td>unknown</td>
+      </tr>
+      <tr>
+        <td class="bullet-left">Configuration</td>
+        <td><div class="bullet-right">
+          
+            OCI_ROOT_URL=http://10.7.22.71:8082/<br />
+          
+            OCI_NAMESPACE=docker-local/testimg<br />
+          
+            OCI_USERNAME=*****<br />
+          
+            OCI_PASSWORD=*****<br />
+          
+            OCI_DEBUG=0<br />
+          
+            OCI_TEST_PULL=1<br />
+          
+            OCI_TEST_PUSH=1<br />
+          
+            OCI_TEST_CONTENT_DISCOVERY=1<br />
+          
+            OCI_TEST_CONTENT_MANAGEMENT=1<br />
+          
+            OCI_HIDE_SKIPPED_WORKFLOWS=0<br />
+          
+            OCI_CROSSMOUNT_NAMESPACE=docker-local/othertest<br />
+          
+        </div></td>
+      </tr>
+    </table>
+
+    <div>
+      
+        
+        
+          
+          
+            
+              <h2>Pull</h2>
+              <div class="subcategory">
+              
+              
+                <h3>Setup</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-0-button" class="toggle" onclick="javascript:toggleOutput('output-box-0')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-0')">Populate registry with test blob</h4>
+                        <br>
+                        <div id="output-box-0" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:07.693344 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:07.693119&#43;03:00
+TIME DURATION: 31.046667ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:07.693374 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:07.787720 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:07.787507&#43;03:00
+TIME DURATION: 94.129167ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 8cb3d6f7-e40d-42f8-9063-f36c51218152
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/8cb3d6f7-e40d-42f8-9063-f36c51218152
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:07.790200 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/8cb3d6f7-e40d-42f8-9063-f36c51218152?digest=sha256%3Aa31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJTdDVyUExRLVdpRU1QRWJOIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:07.790029&#43;03:00
+TIME DURATION: 2.245209ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:07.790228 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:07.888628 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/8cb3d6f7-e40d-42f8-9063-f36c51218152?digest=sha256%3Aa31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJTdDVyUExRLVdpRU1QRWJOIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:07.888068&#43;03:00
+TIME DURATION: 97.828917ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-1-button" class="toggle" onclick="javascript:toggleOutput('output-box-1')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-1')">Populate registry with test layer</h4>
+                        <br>
+                        <div id="output-box-1" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:07.892344 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:07.892028&#43;03:00
+TIME DURATION: 3.268083ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:07.892387 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:07.896718 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:07.896356&#43;03:00
+TIME DURATION: 3.961917ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 8fe9e382-a7b3-433a-ba3c-a35dd3a2a9da
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/8fe9e382-a7b3-433a-ba3c-a35dd3a2a9da
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:07.899393 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/8fe9e382-a7b3-433a-ba3c-a35dd3a2a9da?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:07.898803&#43;03:00
+TIME DURATION: 1.894208ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:07.899452 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:07.909971 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/8fe9e382-a7b3-433a-ba3c-a35dd3a2a9da?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:07.909412&#43;03:00
+TIME DURATION: 9.9335ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-2-button" class="toggle" onclick="javascript:toggleOutput('output-box-2')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-2')">Populate registry with test manifest</h4>
+                        <br>
+                        <div id="output-box-2" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:07.912279 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OmEzMWRlYjVkYTg2ODU5MTUyMzE5OGUwYTIwYjJmZTAxYjExODQ0YzM1YjFiYzcxNGMwODM0Zjg2OTIwMjI0MWMiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUZERWeVVFeFJMVmRwUlUxUVJXSk9JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:07.912015&#43;03:00
+TIME DURATION: 1.84875ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:07.912308 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:07.992763 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OmEzMWRlYjVkYTg2ODU5MTUyMzE5OGUwYTIwYjJmZTAxYjExODQ0YzM1YjFiYzcxNGMwODM0Zjg2OTIwMjI0MWMiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUZERWeVVFeFJMVmRwUlUxUVJXSk9JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:07.991507&#43;03:00
+TIME DURATION: 79.180333ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-3-button" class="toggle" onclick="javascript:toggleOutput('output-box-3')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-3')">Get the name of a tag</h4>
+                        <br>
+                        <div id="output-box-3" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:07.995335 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:07.995041&#43;03:00
+TIME DURATION: 2.102667ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:07.995372 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.026241 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.025688&#43;03:00
+TIME DURATION: 30.307917ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;tagtest0&#34;
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.028965 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OmEzMWRlYjVkYTg2ODU5MTUyMzE5OGUwYTIwYjJmZTAxYjExODQ0YzM1YjFiYzcxNGMwODM0Zjg2OTIwMjI0MWMiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUZERWeVVFeFJMVmRwUlUxUVJXSk9JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.028434&#43;03:00
+TIME DURATION: 1.760834ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.029014 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.064083 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OmEzMWRlYjVkYTg2ODU5MTUyMzE5OGUwYTIwYjJmZTAxYjExODQ0YzM1YjFiYzcxNGMwODM0Zjg2OTIwMjI0MWMiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUZERWeVVFeFJMVmRwUlUxUVJXSk9JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.063421&#43;03:00
+TIME DURATION: 34.379958ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result grey">
+                        <div id="output-box-4-button" class="toggle" onclick="javascript:toggleOutput('output-box-4')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-4')">Get tag name from environment</h4>
+                        <br>
+                        <div id="output-box-4" style="display: none;">
+                          <pre class="pre-box">you have skipped this test.</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Pull blobs</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-5-button" class="toggle" onclick="javascript:toggleOutput('output-box-5')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-5')">HEAD request to nonexistent blob should result in 404 response</h4>
+                        <br>
+                        <div id="output-box-5" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.067669 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/blobs/sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.067153&#43;03:00
+TIME DURATION: 2.167875ms
+HEADERS      :
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+*** Error: Unable to format response body - &#34;unexpected end of JSON input&#34; ***
+
+Log Body as-is:
+
+==============================================================================
+
+2023/04/04 16:24:08.067720 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.095121 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/blobs/sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.094752&#43;03:00
+TIME DURATION: 27.022458ms
+HEADERS      :
+	Content-Length: 168
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+*** Error: Unable to format response body - &#34;unexpected end of JSON input&#34; ***
+
+Log Body as-is:
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-6-button" class="toggle" onclick="javascript:toggleOutput('output-box-6')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-6')">HEAD request to existing blob should yield 200</h4>
+                        <br>
+                        <div id="output-box-6" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.098734 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/blobs/sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.097134&#43;03:00
+TIME DURATION: 1.906125ms
+HEADERS      :
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+*** Error: Unable to format response body - &#34;unexpected end of JSON input&#34; ***
+
+Log Body as-is:
+
+==============================================================================
+
+2023/04/04 16:24:08.098783 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.102406 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/blobs/sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.101814&#43;03:00
+TIME DURATION: 3.022042ms
+HEADERS      :
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-7-button" class="toggle" onclick="javascript:toggleOutput('output-box-7')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-7')">GET nonexistent blob should result in 404 response</h4>
+                        <br>
+                        <div id="output-box-7" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.104922 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.104044&#43;03:00
+TIME DURATION: 1.515125ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.104992 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.117979 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.116658&#43;03:00
+TIME DURATION: 11.655542ms
+HEADERS      :
+	Content-Length: 168
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;BLOB_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;blob unknown to registry&#34;,
+         &#34;detail&#34;: {
+            &#34;blobSum&#34;: &#34;sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-8-button" class="toggle" onclick="javascript:toggleOutput('output-box-8')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-8')">GET request to existing blob URL should yield 200</h4>
+                        <br>
+                        <div id="output-box-8" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.119991 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.119858&#43;03:00
+TIME DURATION: 1.817791ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.120010 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.145835 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.145218&#43;03:00
+TIME DURATION: 25.203584ms
+HEADERS      :
+	Accept-Ranges: bytes
+	Content-Disposition: attachment; filename=&#34;sha256__a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c&#34;
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c
+	Docker-Distribution-Api-Version: registry/2.0
+	Etag: bc65de7c28f511fe17534c0aec728f9ad296870d
+	Last-Modified: Tue, 04 Apr 2023 13:24:07 GMT
+	X-Artifactory-Filename: sha256__a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Checksum-Md5: 24a077091ddabd8b660e6ca2dbbf57dc
+	X-Checksum-Sha1: bc65de7c28f511fe17534c0aec728f9ad296870d
+	X-Checksum-Sha256: a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+	&#34;author&#34;: &#34;St5rPLQ-WiEMPEbN&#34;,
+	&#34;architecture&#34;: &#34;amd64&#34;,
+	&#34;os&#34;: &#34;linux&#34;,
+	&#34;rootfs&#34;: {
+		&#34;type&#34;: &#34;layers&#34;,
+		&#34;diff_ids&#34;: []
+	}
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Pull manifests</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-9-button" class="toggle" onclick="javascript:toggleOutput('output-box-9')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-9')">HEAD request to nonexistent manifest should return 404</h4>
+                        <br>
+                        <div id="output-box-9" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.148093 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/manifests/.INVALID_MANIFEST_NAME  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.147829&#43;03:00
+TIME DURATION: 1.877667ms
+HEADERS      :
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+*** Error: Unable to format response body - &#34;unexpected end of JSON input&#34; ***
+
+Log Body as-is:
+
+==============================================================================
+
+2023/04/04 16:24:08.148132 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.154482 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/manifests/.INVALID_MANIFEST_NAME  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.15414&#43;03:00
+TIME DURATION: 6.001417ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Docker-Registry: docker-local
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+*** Error: Unable to format response body - &#34;unexpected end of JSON input&#34; ***
+
+Log Body as-is:
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-10-button" class="toggle" onclick="javascript:toggleOutput('output-box-10')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-10')">HEAD request to manifest path (digest) should yield 200 response</h4>
+                        <br>
+                        <div id="output-box-10" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.156781 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/manifests/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.156341&#43;03:00
+TIME DURATION: 1.767708ms
+HEADERS      :
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+*** Error: Unable to format response body - &#34;unexpected end of JSON input&#34; ***
+
+Log Body as-is:
+
+==============================================================================
+
+2023/04/04 16:24:08.156843 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.170276 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+HEAD  /v2/docker-local/testimg/manifests/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.17004&#43;03:00
+TIME DURATION: 13.185875ms
+HEADERS      :
+	Accept-Ranges: bytes
+	Cache-Control: no-store
+	Content-Disposition: attachment; filename=&#34;manifest.json&#34;
+	Content-Length: 671
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	Docker-Distribution-Api-Version: registry/2.0
+	Etag: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	Last-Modified: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Docker-Registry: docker-local
+	X-Artifactory-Filename: manifest.json
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Checksum-Md5: 153ef121962cc36e6a46b09a8d4d996b
+	X-Checksum-Sha1: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	X-Checksum-Sha256: c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+*** Error: Unable to format response body - &#34;unexpected end of JSON input&#34; ***
+
+Log Body as-is:
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-11-button" class="toggle" onclick="javascript:toggleOutput('output-box-11')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-11')">HEAD request to manifest path (tag) should yield 200 response</h4>
+                        <br>
+                        <div id="output-box-11" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.172772 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.172237&#43;03:00
+TIME DURATION: 1.891791ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.172834 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.180409 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.178587&#43;03:00
+TIME DURATION: 5.743584ms
+HEADERS      :
+	Accept-Ranges: bytes
+	Cache-Control: no-store
+	Content-Disposition: attachment; filename=&#34;manifest.json&#34;
+	Content-Length: 671
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	Docker-Distribution-Api-Version: registry/2.0
+	Etag: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	Last-Modified: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Filename: manifest.json
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Checksum-Md5: 153ef121962cc36e6a46b09a8d4d996b
+	X-Checksum-Sha1: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	X-Checksum-Sha256: c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;schemaVersion&#34;: 2,
+   &#34;config&#34;: {
+      &#34;mediaType&#34;: &#34;application/vnd.oci.image.config.v1&#43;json&#34;,
+      &#34;digest&#34;: &#34;sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c&#34;,
+      &#34;size&#34;: 129,
+      &#34;data&#34;: &#34;ewoJImF1dGhvciI6ICJTdDVyUExRLVdpRU1QRWJOIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9&#34;,
+      &#34;newUnspecifiedField&#34;: &#34;aGVsbG8gd29ybGQ=&#34;
+   },
+   &#34;layers&#34;: [
+      {
+         &#34;mediaType&#34;: &#34;application/vnd.oci.image.layer.v1.tar&#43;gzip&#34;,
+         &#34;digest&#34;: &#34;sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183&#34;,
+         &#34;size&#34;: 168,
+         &#34;data&#34;: null,
+         &#34;newUnspecifiedField&#34;: null
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-12-button" class="toggle" onclick="javascript:toggleOutput('output-box-12')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-12')">GET nonexistent manifest should return 404</h4>
+                        <br>
+                        <div id="output-box-12" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.183289 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/.INVALID_MANIFEST_NAME  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.182907&#43;03:00
+TIME DURATION: 2.353083ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.183339 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.186859 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/.INVALID_MANIFEST_NAME  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.186489&#43;03:00
+TIME DURATION: 3.136292ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;MANIFEST_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;The named manifest is not known to the registry.&#34;,
+         &#34;detail&#34;: {
+            &#34;manifest&#34;: &#34;testimg/.INVALID_MANIFEST_NAME/manifest.json&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-13-button" class="toggle" onclick="javascript:toggleOutput('output-box-13')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-13')">GET request to manifest path (digest) should yield 200 response</h4>
+                        <br>
+                        <div id="output-box-13" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.188921 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.188767&#43;03:00
+TIME DURATION: 1.847708ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.188946 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.194839 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.194&#43;03:00
+TIME DURATION: 5.0495ms
+HEADERS      :
+	Accept-Ranges: bytes
+	Cache-Control: no-store
+	Content-Disposition: attachment; filename=&#34;manifest.json&#34;
+	Content-Length: 671
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	Docker-Distribution-Api-Version: registry/2.0
+	Etag: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	Last-Modified: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Filename: manifest.json
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Checksum-Md5: 153ef121962cc36e6a46b09a8d4d996b
+	X-Checksum-Sha1: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	X-Checksum-Sha256: c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;schemaVersion&#34;: 2,
+   &#34;config&#34;: {
+      &#34;mediaType&#34;: &#34;application/vnd.oci.image.config.v1&#43;json&#34;,
+      &#34;digest&#34;: &#34;sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c&#34;,
+      &#34;size&#34;: 129,
+      &#34;data&#34;: &#34;ewoJImF1dGhvciI6ICJTdDVyUExRLVdpRU1QRWJOIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9&#34;,
+      &#34;newUnspecifiedField&#34;: &#34;aGVsbG8gd29ybGQ=&#34;
+   },
+   &#34;layers&#34;: [
+      {
+         &#34;mediaType&#34;: &#34;application/vnd.oci.image.layer.v1.tar&#43;gzip&#34;,
+         &#34;digest&#34;: &#34;sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183&#34;,
+         &#34;size&#34;: 168,
+         &#34;data&#34;: null,
+         &#34;newUnspecifiedField&#34;: null
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-14-button" class="toggle" onclick="javascript:toggleOutput('output-box-14')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-14')">GET request to manifest path (tag) should yield 200 response</h4>
+                        <br>
+                        <div id="output-box-14" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.196926 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.196607&#43;03:00
+TIME DURATION: 1.656333ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.196966 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.202281 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.201988&#43;03:00
+TIME DURATION: 5.010375ms
+HEADERS      :
+	Accept-Ranges: bytes
+	Cache-Control: no-store
+	Content-Disposition: attachment; filename=&#34;manifest.json&#34;
+	Content-Length: 671
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	Docker-Distribution-Api-Version: registry/2.0
+	Etag: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	Last-Modified: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Filename: manifest.json
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Checksum-Md5: 153ef121962cc36e6a46b09a8d4d996b
+	X-Checksum-Sha1: 13d49cb71d1dc9e354f9a697cc73b8148ed771e7
+	X-Checksum-Sha256: c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;schemaVersion&#34;: 2,
+   &#34;config&#34;: {
+      &#34;mediaType&#34;: &#34;application/vnd.oci.image.config.v1&#43;json&#34;,
+      &#34;digest&#34;: &#34;sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c&#34;,
+      &#34;size&#34;: 129,
+      &#34;data&#34;: &#34;ewoJImF1dGhvciI6ICJTdDVyUExRLVdpRU1QRWJOIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9&#34;,
+      &#34;newUnspecifiedField&#34;: &#34;aGVsbG8gd29ybGQ=&#34;
+   },
+   &#34;layers&#34;: [
+      {
+         &#34;mediaType&#34;: &#34;application/vnd.oci.image.layer.v1.tar&#43;gzip&#34;,
+         &#34;digest&#34;: &#34;sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183&#34;,
+         &#34;size&#34;: 168,
+         &#34;data&#34;: null,
+         &#34;newUnspecifiedField&#34;: null
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Error codes</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-15-button" class="toggle" onclick="javascript:toggleOutput('output-box-15')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-15')">400 response body should contain OCI-conforming JSON message</h4>
+                        <br>
+                        <div id="output-box-15" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.204235 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/sha256:totallywrong  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;YmxhYmxhYmxh&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.20408&#43;03:00
+TIME DURATION: 1.737708ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.204257 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.210761 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/sha256:totallywrong  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;YmxhYmxhYmxh&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 400 Bad Request
+RECEIVED AT  : 2023-04-04T16:24:08.209795&#43;03:00
+TIME DURATION: 5.52425ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;MANIFEST_INVALID&#34;,
+         &#34;message&#34;: &#34;manifest invalid&#34;,
+         &#34;detail&#34;: {
+            &#34;description&#34;: &#34;com.fasterxml.jackson.core.JsonParseException: Unrecognized token &#39;blablabla&#39;: was expecting (JSON String, Number, Array, Object or token &#39;null&#39;, &#39;true&#39; or &#39;false&#39;)  at [Source: (byte[])&#39;blablabla&#39;; line: 1, column: 10]&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Teardown</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-16-button" class="toggle" onclick="javascript:toggleOutput('output-box-16')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-16')">Delete config blob created in setup</h4>
+                        <br>
+                        <div id="output-box-16" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.213454 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.213118&#43;03:00
+TIME DURATION: 2.138084ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.213506 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.223312 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:a31deb5da868591523198e0a20b2fe01b11844c35b1bc714c0834f869202241c  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 405 Method Not Allowed
+RECEIVED AT  : 2023-04-04T16:24:08.222746&#43;03:00
+TIME DURATION: 9.23375ms
+HEADERS      :
+	Allow: HEAD,GET,OPTIONS
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 405,
+         &#34;message&#34;: &#34;Method Not Allowed&#34;
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-17-button" class="toggle" onclick="javascript:toggleOutput('output-box-17')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-17')">Delete layer blob created in setup</h4>
+                        <br>
+                        <div id="output-box-17" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.225644 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.225186&#43;03:00
+TIME DURATION: 1.746958ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.225699 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.227878 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 405 Method Not Allowed
+RECEIVED AT  : 2023-04-04T16:24:08.227584&#43;03:00
+TIME DURATION: 1.8765ms
+HEADERS      :
+	Allow: HEAD,GET,OPTIONS
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 405,
+         &#34;message&#34;: &#34;Method Not Allowed&#34;
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-18-button" class="toggle" onclick="javascript:toggleOutput('output-box-18')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-18')">Delete manifest created in setup</h4>
+                        <br>
+                        <div id="output-box-18" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.230014 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.229512&#43;03:00
+TIME DURATION: 1.582708ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.230084 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.259791 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:c16bb42cb2fac5fcbdb423d1dbac8f520f2bab91336bc5d488bd87b4bad39edb  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.259406&#43;03:00
+TIME DURATION: 29.3125ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+            
+          
+        </div>
+        
+          
+          
+            
+              <h2>Push</h2>
+              <div class="subcategory">
+              
+              
+                <h3>Blob Upload Streamed</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-19-button" class="toggle" onclick="javascript:toggleOutput('output-box-19')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-19')">PATCH request with blob in body should yield 202 response</h4>
+                        <br>
+                        <div id="output-box-19" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.269910 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.269567&#43;03:00
+TIME DURATION: 9.655458ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.269962 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.284031 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.283645&#43;03:00
+TIME DURATION: 13.674042ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 43dc00a4-b027-4bf2-8c56-0dd452567efe
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/43dc00a4-b027-4bf2-8c56-0dd452567efe
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.288251 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PATCH  /v2/docker-local/testimg/blobs/uploads/43dc00a4-b027-4bf2-8c56-0dd452567efe  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+TkJBIEphbSBvbiBteSBOQkEgdG9hc3Q=
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.287613&#43;03:00
+TIME DURATION: 3.278792ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.288326 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.302656 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PATCH  /v2/docker-local/testimg/blobs/uploads/43dc00a4-b027-4bf2-8c56-0dd452567efe  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+TkJBIEphbSBvbiBteSBOQkEgdG9hc3Q=
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.302265&#43;03:00
+TIME DURATION: 13.922292ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 43dc00a4-b027-4bf2-8c56-0dd452567efe
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/43dc00a4-b027-4bf2-8c56-0dd452567efe
+	Range: 0-22
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-20-button" class="toggle" onclick="javascript:toggleOutput('output-box-20')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-20')">PUT request to session URL with digest should yield 201 response</h4>
+                        <br>
+                        <div id="output-box-20" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.305118 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/43dc00a4-b027-4bf2-8c56-0dd452567efe?digest=sha256%3A852411eaf653ebebfa34b688ad1736c9da4decadb8f55b839b550d64eaad3f75  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 23
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.304783&#43;03:00
+TIME DURATION: 1.990917ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.306381 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.322086 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/43dc00a4-b027-4bf2-8c56-0dd452567efe?digest=sha256%3A852411eaf653ebebfa34b688ad1736c9da4decadb8f55b839b550d64eaad3f75  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 23
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.321343&#43;03:00
+TIME DURATION: 14.943292ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:852411eaf653ebebfa34b688ad1736c9da4decadb8f55b839b550d64eaad3f75
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:852411eaf653ebebfa34b688ad1736c9da4decadb8f55b839b550d64eaad3f75
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Blob Upload Monolithic</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-21-button" class="toggle" onclick="javascript:toggleOutput('output-box-21')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-21')">GET nonexistent blob should result in 404 response</h4>
+                        <br>
+                        <div id="output-box-21" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.327117 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.326755&#43;03:00
+TIME DURATION: 4.552334ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.327175 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.332313 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.331865&#43;03:00
+TIME DURATION: 4.682167ms
+HEADERS      :
+	Content-Length: 168
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;BLOB_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;blob unknown to registry&#34;,
+         &#34;detail&#34;: {
+            &#34;blobSum&#34;: &#34;sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-22-button" class="toggle" onclick="javascript:toggleOutput('output-box-22')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-22')">POST request with digest and blob should yield a 201 or 202</h4>
+                        <br>
+                        <div id="output-box-22" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.336929 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/?digest=sha256%3A8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJTYjYzNjRoY2FFRDRKNExMIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.336427&#43;03:00
+TIME DURATION: 3.987541ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.337033 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.342111 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/?digest=sha256%3A8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJTYjYzNjRoY2FFRDRKNExMIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.341666&#43;03:00
+TIME DURATION: 4.621375ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: abab5275-081e-46e5-b040-e4130821cf19
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/abab5275-081e-46e5-b040-e4130821cf19
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-23-button" class="toggle" onclick="javascript:toggleOutput('output-box-23')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-23')">GET request to blob URL from prior request should yield 200 or 404 based on response code</h4>
+                        <br>
+                        <div id="output-box-23" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.346598 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.34625&#43;03:00
+TIME DURATION: 3.855583ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.346661 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.351174 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.350533&#43;03:00
+TIME DURATION: 3.863791ms
+HEADERS      :
+	Content-Length: 168
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;BLOB_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;blob unknown to registry&#34;,
+         &#34;detail&#34;: {
+            &#34;blobSum&#34;: &#34;sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-24-button" class="toggle" onclick="javascript:toggleOutput('output-box-24')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-24')">POST request should yield a session ID</h4>
+                        <br>
+                        <div id="output-box-24" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.354951 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.354759&#43;03:00
+TIME DURATION: 3.036333ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.354979 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.360019 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.359845&#43;03:00
+TIME DURATION: 4.862083ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 2f725359-310c-479d-a033-91028b21d8f5
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/2f725359-310c-479d-a033-91028b21d8f5
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-25-button" class="toggle" onclick="javascript:toggleOutput('output-box-25')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-25')">PUT upload of a blob should yield a 201 Response</h4>
+                        <br>
+                        <div id="output-box-25" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.362518 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/2f725359-310c-479d-a033-91028b21d8f5?digest=sha256%3A8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJTYjYzNjRoY2FFRDRKNExMIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.362126&#43;03:00
+TIME DURATION: 2.030417ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.362611 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.372321 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/2f725359-310c-479d-a033-91028b21d8f5?digest=sha256%3A8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJTYjYzNjRoY2FFRDRKNExMIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.371609&#43;03:00
+TIME DURATION: 8.97775ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result red">
+                        <div id="output-box-26-button" class="toggle" onclick="javascript:toggleOutput('output-box-26')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-26')">GET request to existing blob should yield 200 response</h4>
+                        <br>
+                        <div>
+                          <div id="output-box-26" style="display: none;">
+                            <pre class="pre-box">2023/04/04 16:24:08.374781 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.374595&#43;03:00
+TIME DURATION: 2.158959ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.374807 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.378154 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.377965&#43;03:00
+TIME DURATION: 3.154333ms
+HEADERS      :
+	Content-Length: 168
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;BLOB_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;blob unknown to registry&#34;,
+         &#34;detail&#34;: {
+            &#34;blobSum&#34;: &#34;sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                          </div>
+                        </div>
+                        <pre class="fail-message">Expected
+    &lt;int&gt;: 404
+to equal
+    &lt;int&gt;: 200</pre>
+                        <br>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-27-button" class="toggle" onclick="javascript:toggleOutput('output-box-27')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-27')">PUT upload of a layer blob should yield a 201 Response</h4>
+                        <br>
+                        <div id="output-box-27" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.380981 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.380685&#43;03:00
+TIME DURATION: 2.310916ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.381024 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.383951 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.383807&#43;03:00
+TIME DURATION: 2.776709ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 930e0f49-53f3-47f3-8b44-02ddc9d20647
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/930e0f49-53f3-47f3-8b44-02ddc9d20647
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.385626 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/930e0f49-53f3-47f3-8b44-02ddc9d20647?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.385465&#43;03:00
+TIME DURATION: 1.47925ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.385651 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.393650 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/930e0f49-53f3-47f3-8b44-02ddc9d20647?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.393108&#43;03:00
+TIME DURATION: 7.4495ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result red">
+                        <div id="output-box-28-button" class="toggle" onclick="javascript:toggleOutput('output-box-28')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-28')">GET request to existing layer should yield 200 response</h4>
+                        <br>
+                        <div>
+                          <div id="output-box-28" style="display: none;">
+                            <pre class="pre-box">2023/04/04 16:24:08.395440 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.395092&#43;03:00
+TIME DURATION: 1.296917ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.395485 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.398564 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.398138&#43;03:00
+TIME DURATION: 2.644958ms
+HEADERS      :
+	Content-Length: 168
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;BLOB_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;blob unknown to registry&#34;,
+         &#34;detail&#34;: {
+            &#34;blobSum&#34;: &#34;sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                          </div>
+                        </div>
+                        <pre class="fail-message">Expected
+    &lt;int&gt;: 404
+to equal
+    &lt;int&gt;: 200</pre>
+                        <br>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Blob Upload Chunked</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-29-button" class="toggle" onclick="javascript:toggleOutput('output-box-29')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-29')">Out-of-order blob upload should return 416</h4>
+                        <br>
+                        <div id="output-box-29" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.401746 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 0
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.401304&#43;03:00
+TIME DURATION: 2.184625ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.401802 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.405021 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 0
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.404528&#43;03:00
+TIME DURATION: 2.716125ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: d47444da-9e61-4937-b2d0-398569caabb6
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/d47444da-9e61-4937-b2d0-398569caabb6
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.406903 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PATCH  /v2/docker-local/testimg/blobs/uploads/d47444da-9e61-4937-b2d0-398569caabb6  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 22
+	Content-Range: 3-24
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+bG8sIGhvdyBhcmUgeW91IHRvZGF5Pw==
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.406456&#43;03:00
+TIME DURATION: 1.336334ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.406968 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.409109 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PATCH  /v2/docker-local/testimg/blobs/uploads/d47444da-9e61-4937-b2d0-398569caabb6  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 22
+	Content-Range: 3-24
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+bG8sIGhvdyBhcmUgeW91IHRvZGF5Pw==
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 416 Requested Range Not Satisfiable
+RECEIVED AT  : 2023-04-04T16:24:08.408532&#43;03:00
+TIME DURATION: 1.54ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;REQUESTED_RANGE_NOT_SATISFIABLE&#34;,
+         &#34;message&#34;: &#34;There was an error processing the upload and it must be restarted.&#34;,
+         &#34;detail&#34;: {
+            &#34;description&#34;: &#34;Illegal range, should start with 0&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-30-button" class="toggle" onclick="javascript:toggleOutput('output-box-30')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-30')">PATCH request with first chunk should return 202</h4>
+                        <br>
+                        <div id="output-box-30" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.411547 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 0
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.411264&#43;03:00
+TIME DURATION: 2.082708ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.411611 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.414809 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 0
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.414444&#43;03:00
+TIME DURATION: 2.826209ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 2b8ec1d2-e7a9-4496-ab1f-34900774495a
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/2b8ec1d2-e7a9-4496-ab1f-34900774495a
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.416427 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PATCH  /v2/docker-local/testimg/blobs/uploads/2b8ec1d2-e7a9-4496-ab1f-34900774495a  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 3
+	Content-Range: 0-2
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+SGVs
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.41625&#43;03:00
+TIME DURATION: 1.371708ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.416459 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.423251 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PATCH  /v2/docker-local/testimg/blobs/uploads/2b8ec1d2-e7a9-4496-ab1f-34900774495a  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 3
+	Content-Range: 0-2
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+SGVs
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.422548&#43;03:00
+TIME DURATION: 6.077958ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 2b8ec1d2-e7a9-4496-ab1f-34900774495a
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/2b8ec1d2-e7a9-4496-ab1f-34900774495a
+	Range: 0-2
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-31-button" class="toggle" onclick="javascript:toggleOutput('output-box-31')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-31')">PUT request with final chunk should return 201</h4>
+                        <br>
+                        <div id="output-box-31" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.426490 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/2b8ec1d2-e7a9-4496-ab1f-34900774495a?digest=sha256%3A6e766a49e512e0ba0bc935e2aacd3e5a4a34add17f83afc4c9e669c70241cd48  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 22
+	Content-Range: 3-24
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+bG8sIGhvdyBhcmUgeW91IHRvZGF5Pw==
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.42614&#43;03:00
+TIME DURATION: 2.700709ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.426551 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.434863 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/2b8ec1d2-e7a9-4496-ab1f-34900774495a?digest=sha256%3A6e766a49e512e0ba0bc935e2aacd3e5a4a34add17f83afc4c9e669c70241cd48  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 22
+	Content-Range: 3-24
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+bG8sIGhvdyBhcmUgeW91IHRvZGF5Pw==
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.434461&#43;03:00
+TIME DURATION: 7.890709ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:6e766a49e512e0ba0bc935e2aacd3e5a4a34add17f83afc4c9e669c70241cd48
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:6e766a49e512e0ba0bc935e2aacd3e5a4a34add17f83afc4c9e669c70241cd48
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Cross-Repository Blob Mount</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-32-button" class="toggle" onclick="javascript:toggleOutput('output-box-32')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-32')">Cross-mounting of a blob without the from argument should yield session id</h4>
+                        <br>
+                        <div id="output-box-32" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.437558 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/othertest/blobs/uploads/?mount=sha256%3Ab94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.437268&#43;03:00
+TIME DURATION: 2.272333ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.437596 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.441573 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/othertest/blobs/uploads/?mount=sha256%3Ab94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.441243&#43;03:00
+TIME DURATION: 3.6405ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: d24caede-8501-4c6c-9710-3f0baca66c05
+	Location: http://10.7.22.71:8082/v2/docker-local/othertest/blobs/uploads/d24caede-8501-4c6c-9710-3f0baca66c05
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-33-button" class="toggle" onclick="javascript:toggleOutput('output-box-33')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-33')">POST request to mount another repository&#39;s blob should return 201 or 202</h4>
+                        <br>
+                        <div id="output-box-33" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.444467 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/othertest/blobs/uploads/?from=docker-local%2Ftestimg&amp;mount=sha256%3A852411eaf653ebebfa34b688ad1736c9da4decadb8f55b839b550d64eaad3f75  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.444179&#43;03:00
+TIME DURATION: 2.507ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.444507 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.449919 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/othertest/blobs/uploads/?from=docker-local%2Ftestimg&amp;mount=sha256%3A852411eaf653ebebfa34b688ad1736c9da4decadb8f55b839b550d64eaad3f75  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.449758&#43;03:00
+TIME DURATION: 5.245417ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: a90ce9f7-c3a0-4516-8ece-3963a5f7815d
+	Location: http://10.7.22.71:8082/v2/docker-local/othertest/blobs/uploads/a90ce9f7-c3a0-4516-8ece-3963a5f7815d
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result grey">
+                        <div id="output-box-34-button" class="toggle" onclick="javascript:toggleOutput('output-box-34')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-34')">GET request to test digest within cross-mount namespace should return 200</h4>
+                        <br>
+                        <div id="output-box-34" style="display: none;">
+                          <pre class="pre-box">you have skipped this test.</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-35-button" class="toggle" onclick="javascript:toggleOutput('output-box-35')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-35')">Cross-mounting of nonexistent blob should yield session id</h4>
+                        <br>
+                        <div id="output-box-35" style="display: none;">
+                          <pre class="pre-box"></pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result grey">
+                        <div id="output-box-36-button" class="toggle" onclick="javascript:toggleOutput('output-box-36')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-36')">Cross-mounting without from, and automatic content discovery enabled should return a 201</h4>
+                        <br>
+                        <div id="output-box-36" style="display: none;">
+                          <pre class="pre-box">you have skipped this test.</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result grey">
+                        <div id="output-box-37-button" class="toggle" onclick="javascript:toggleOutput('output-box-37')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-37')">Cross-mounting without from, and automatic content discovery disabled should return a 202</h4>
+                        <br>
+                        <div id="output-box-37" style="display: none;">
+                          <pre class="pre-box">you have skipped this test.</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Manifest Upload</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-38-button" class="toggle" onclick="javascript:toggleOutput('output-box-38')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-38')">GET nonexistent manifest should return 404</h4>
+                        <br>
+                        <div id="output-box-38" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.452373 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/.INVALID_MANIFEST_NAME  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.452213&#43;03:00
+TIME DURATION: 1.829916ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.452397 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.455754 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/.INVALID_MANIFEST_NAME  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.454951&#43;03:00
+TIME DURATION: 2.550333ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;MANIFEST_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;The named manifest is not known to the registry.&#34;,
+         &#34;detail&#34;: {
+            &#34;manifest&#34;: &#34;testimg/.INVALID_MANIFEST_NAME/manifest.json&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-39-button" class="toggle" onclick="javascript:toggleOutput('output-box-39')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-39')">PUT should accept a manifest upload</h4>
+                        <br>
+                        <div id="output-box-39" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.458192 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.457628&#43;03:00
+TIME DURATION: 1.68475ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.458371 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.482684 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.481883&#43;03:00
+TIME DURATION: 23.479167ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.484873 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test1  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.484577&#43;03:00
+TIME DURATION: 1.8195ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.485173 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.506376 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test1  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.505669&#43;03:00
+TIME DURATION: 20.477542ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.508848 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.508263&#43;03:00
+TIME DURATION: 1.79ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.508896 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.527433 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.52682&#43;03:00
+TIME DURATION: 17.86625ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.530145 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test3  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.529632&#43;03:00
+TIME DURATION: 2.101625ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.530183 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.547689 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test3  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.546839&#43;03:00
+TIME DURATION: 16.62925ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-40-button" class="toggle" onclick="javascript:toggleOutput('output-box-40')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-40')">Registry should accept a manifest upload with no layers</h4>
+                        <br>
+                        <div id="output-box-40" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.550177 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/emptylayer  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFtdCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.549723&#43;03:00
+TIME DURATION: 1.855125ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.550223 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.571144 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/emptylayer  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjhjZDFlMDNhNGEyYTk3MjFlZWQ2MzhkZWY5NGNmNjNjZjc5ZjM3ODE5YWEzNzNiNTMxMDVlMDFhMDBiZDVlNjkiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pUWWpZek5qUm9ZMkZGUkRSS05FeE1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFtdCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.570387&#43;03:00
+TIME DURATION: 20.142625ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:25ac71f188bb8fe038e1673d4a4eccbf5ae5cfb68c0627fb5408ae4ddfbd2ab2
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:25ac71f188bb8fe038e1673d4a4eccbf5ae5cfb68c0627fb5408ae4ddfbd2ab2
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-41-button" class="toggle" onclick="javascript:toggleOutput('output-box-41')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-41')">GET request to manifest URL (digest) should yield 200 response</h4>
+                        <br>
+                        <div id="output-box-41" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.573690 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.573307&#43;03:00
+TIME DURATION: 2.047208ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.573743 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.580593 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.579187&#43;03:00
+TIME DURATION: 5.436209ms
+HEADERS      :
+	Accept-Ranges: bytes
+	Cache-Control: no-store
+	Content-Disposition: attachment; filename=&#34;manifest.json&#34;
+	Content-Length: 671
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	Docker-Distribution-Api-Version: registry/2.0
+	Etag: e397b524dcb91c76e7856def5ca5f9e3a8a0e409
+	Last-Modified: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Filename: manifest.json
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Checksum-Md5: 34a773d6454d87ee72a99081520c32c1
+	X-Checksum-Sha1: e397b524dcb91c76e7856def5ca5f9e3a8a0e409
+	X-Checksum-Sha256: 886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;schemaVersion&#34;: 2,
+   &#34;config&#34;: {
+      &#34;mediaType&#34;: &#34;application/vnd.oci.image.config.v1&#43;json&#34;,
+      &#34;digest&#34;: &#34;sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69&#34;,
+      &#34;size&#34;: 129,
+      &#34;data&#34;: &#34;ewoJImF1dGhvciI6ICJTYjYzNjRoY2FFRDRKNExMIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9&#34;,
+      &#34;newUnspecifiedField&#34;: &#34;aGVsbG8gd29ybGQ=&#34;
+   },
+   &#34;layers&#34;: [
+      {
+         &#34;mediaType&#34;: &#34;application/vnd.oci.image.layer.v1.tar&#43;gzip&#34;,
+         &#34;digest&#34;: &#34;sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183&#34;,
+         &#34;size&#34;: 168,
+         &#34;data&#34;: null,
+         &#34;newUnspecifiedField&#34;: null
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Teardown</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-42-button" class="toggle" onclick="javascript:toggleOutput('output-box-42')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-42')">Delete config blob created in tests</h4>
+                        <br>
+                        <div id="output-box-42" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.582731 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.582352&#43;03:00
+TIME DURATION: 1.6065ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.582777 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.585018 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:8cd1e03a4a2a9721eed638def94cf63cf79f37819aa373b53105e01a00bd5e69  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 405 Method Not Allowed
+RECEIVED AT  : 2023-04-04T16:24:08.584488&#43;03:00
+TIME DURATION: 1.704375ms
+HEADERS      :
+	Allow: HEAD,GET,OPTIONS
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 405,
+         &#34;message&#34;: &#34;Method Not Allowed&#34;
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-43-button" class="toggle" onclick="javascript:toggleOutput('output-box-43')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-43')">Delete layer blob created in setup</h4>
+                        <br>
+                        <div id="output-box-43" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.586681 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.58652&#43;03:00
+TIME DURATION: 1.40225ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.586711 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.588644 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 405 Method Not Allowed
+RECEIVED AT  : 2023-04-04T16:24:08.588252&#43;03:00
+TIME DURATION: 1.537875ms
+HEADERS      :
+	Allow: HEAD,GET,OPTIONS
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 405,
+         &#34;message&#34;: &#34;Method Not Allowed&#34;
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-44-button" class="toggle" onclick="javascript:toggleOutput('output-box-44')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-44')">Delete manifest created in tests</h4>
+                        <br>
+                        <div id="output-box-44" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.590396 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.59026&#43;03:00
+TIME DURATION: 1.567375ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.590417 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.643989 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:886a42d2d7238eb0c157819d9629ce1e4cbb96d830f51ae1b75f1e6bb1363aea  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.641675&#43;03:00
+TIME DURATION: 51.254666ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+            
+          
+        </div>
+        
+          
+          
+            
+              <h2>Content Discovery</h2>
+              <div class="subcategory">
+              
+              
+                <h3>Setup</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-45-button" class="toggle" onclick="javascript:toggleOutput('output-box-45')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-45')">Populate registry with test blob</h4>
+                        <br>
+                        <div id="output-box-45" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.652181 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.652034&#43;03:00
+TIME DURATION: 7.893166ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.652202 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.655271 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.655121&#43;03:00
+TIME DURATION: 2.915959ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: 76f797f6-c5eb-4c77-a114-01413f4008d3
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/76f797f6-c5eb-4c77-a114-01413f4008d3
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.656841 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/76f797f6-c5eb-4c77-a114-01413f4008d3?digest=sha256%3A0e064c68417d0f17a99f6061930e3848eecd9acfd481cfc7072a0bf63a6bbb0b  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJFVTRSVm95b0xtVTlIdkRMIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.656673&#43;03:00
+TIME DURATION: 1.341875ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.656869 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.664845 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/76f797f6-c5eb-4c77-a114-01413f4008d3?digest=sha256%3A0e064c68417d0f17a99f6061930e3848eecd9acfd481cfc7072a0bf63a6bbb0b  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICJFVTRSVm95b0xtVTlIdkRMIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.664388&#43;03:00
+TIME DURATION: 7.511042ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:0e064c68417d0f17a99f6061930e3848eecd9acfd481cfc7072a0bf63a6bbb0b
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:0e064c68417d0f17a99f6061930e3848eecd9acfd481cfc7072a0bf63a6bbb0b
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-46-button" class="toggle" onclick="javascript:toggleOutput('output-box-46')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-46')">Populate registry with test layer</h4>
+                        <br>
+                        <div id="output-box-46" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.667730 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.667438&#43;03:00
+TIME DURATION: 2.462041ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.667768 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.672813 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.672126&#43;03:00
+TIME DURATION: 4.351875ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: df53293b-a815-4cf7-9da3-5291de9fcf88
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/df53293b-a815-4cf7-9da3-5291de9fcf88
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.675238 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/df53293b-a815-4cf7-9da3-5291de9fcf88?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.674794&#43;03:00
+TIME DURATION: 1.840333ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.675301 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.684921 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/df53293b-a815-4cf7-9da3-5291de9fcf88?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.684718&#43;03:00
+TIME DURATION: 9.391166ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Docker-Content-Digest: sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-47-button" class="toggle" onclick="javascript:toggleOutput('output-box-47')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-47')">Populate registry with test tags</h4>
+                        <br>
+                        <div id="output-box-47" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.687001 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.686754&#43;03:00
+TIME DURATION: 1.755583ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:07 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.687034 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.712249 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.711978&#43;03:00
+TIME DURATION: 24.923ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Content-Digest: sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.714341 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test1  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.714107&#43;03:00
+TIME DURATION: 1.813166ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.714362 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.733332 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test1  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.732576&#43;03:00
+TIME DURATION: 18.20175ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Content-Digest: sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.735889 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.735339&#43;03:00
+TIME DURATION: 1.893375ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.735930 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.755106 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.75437&#43;03:00
+TIME DURATION: 18.41475ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Content-Digest: sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.757641 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test3  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.756989&#43;03:00
+TIME DURATION: 1.641875ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.757690 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.775975 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/test3  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjBlMDY0YzY4NDE3ZDBmMTdhOTlmNjA2MTkzMGUzODQ4ZWVjZDlhY2ZkNDgxY2ZjNzA3MmEwYmY2M2E2YmJiMGIiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0pGVlRSU1ZtOTViMHh0VlRsSWRrUk1JaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.775037&#43;03:00
+TIME DURATION: 17.315625ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Content-Digest: sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.778143 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.777842&#43;03:00
+TIME DURATION: 1.797417ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.778187 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.784132 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.783804&#43;03:00
+TIME DURATION: 5.609917ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;emptylayer&#34;,
+      &#34;test0&#34;,
+      &#34;test1&#34;,
+      &#34;test2&#34;,
+      &#34;test3&#34;
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result grey">
+                        <div id="output-box-48-button" class="toggle" onclick="javascript:toggleOutput('output-box-48')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-48')">Populate registry with test tags (no push)</h4>
+                        <br>
+                        <div id="output-box-48" style="display: none;">
+                          <pre class="pre-box">you have skipped this test.</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Test content discovery endpoints</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-49-button" class="toggle" onclick="javascript:toggleOutput('output-box-49')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-49')">GET request to list tags should yield 200 response</h4>
+                        <br>
+                        <div id="output-box-49" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.786283 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.785977&#43;03:00
+TIME DURATION: 1.589042ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.786336 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.789645 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.789092&#43;03:00
+TIME DURATION: 2.746459ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;emptylayer&#34;,
+      &#34;test0&#34;,
+      &#34;test1&#34;,
+      &#34;test2&#34;,
+      &#34;test3&#34;
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-50-button" class="toggle" onclick="javascript:toggleOutput('output-box-50')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-50')">GET number of tags should be limitable by `n` query parameter</h4>
+                        <br>
+                        <div id="output-box-50" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.791438 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list?n=2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.791036&#43;03:00
+TIME DURATION: 1.286125ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.791487 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.795496 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list?n=2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.795041&#43;03:00
+TIME DURATION: 3.54625ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Link: &lt;/v2/testimg/tags/list?last=test0&amp;n=2&gt;; rel=&#34;next&#34;
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;emptylayer&#34;,
+      &#34;test0&#34;
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-51-button" class="toggle" onclick="javascript:toggleOutput('output-box-51')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-51')">GET start of tag is set by `last` query parameter</h4>
+                        <br>
+                        <div id="output-box-51" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.801057 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list?n=2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.800902&#43;03:00
+TIME DURATION: 5.270667ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.801078 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.805217 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list?n=2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.804777&#43;03:00
+TIME DURATION: 3.695291ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Link: &lt;/v2/testimg/tags/list?last=test0&amp;n=2&gt;; rel=&#34;next&#34;
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;emptylayer&#34;,
+      &#34;test0&#34;
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.807258 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list?last=test0&amp;n=2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.806938&#43;03:00
+TIME DURATION: 1.677417ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.807305 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.810565 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list?last=test0&amp;n=2  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.809808&#43;03:00
+TIME DURATION: 2.494666ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Link: &lt;/v2/testimg/tags/list?last=test2&amp;n=2&gt;; rel=&#34;next&#34;
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;test1&#34;,
+      &#34;test2&#34;
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Teardown</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-52-button" class="toggle" onclick="javascript:toggleOutput('output-box-52')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-52')">Delete config blob created in tests</h4>
+                        <br>
+                        <div id="output-box-52" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.812512 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:0e064c68417d0f17a99f6061930e3848eecd9acfd481cfc7072a0bf63a6bbb0b  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.812143&#43;03:00
+TIME DURATION: 1.449125ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.814047 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.816382 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:0e064c68417d0f17a99f6061930e3848eecd9acfd481cfc7072a0bf63a6bbb0b  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 405 Method Not Allowed
+RECEIVED AT  : 2023-04-04T16:24:08.816024&#43;03:00
+TIME DURATION: 1.964333ms
+HEADERS      :
+	Allow: HEAD,GET,OPTIONS
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 405,
+         &#34;message&#34;: &#34;Method Not Allowed&#34;
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-53-button" class="toggle" onclick="javascript:toggleOutput('output-box-53')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-53')">Delete layer blob created in setup</h4>
+                        <br>
+                        <div id="output-box-53" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.817889 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.817749&#43;03:00
+TIME DURATION: 1.305416ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.817910 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.820303 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 405 Method Not Allowed
+RECEIVED AT  : 2023-04-04T16:24:08.819397&#43;03:00
+TIME DURATION: 1.483292ms
+HEADERS      :
+	Allow: HEAD,GET,OPTIONS
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 405,
+         &#34;message&#34;: &#34;Method Not Allowed&#34;
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-54-button" class="toggle" onclick="javascript:toggleOutput('output-box-54')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-54')">Delete created manifest &amp; associated tags</h4>
+                        <br>
+                        <div id="output-box-54" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.822728 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.822342&#43;03:00
+TIME DURATION: 1.754208ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.822783 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.877606 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:5d9e8171f03bfecc5ff4cb0ea6e084186867986929a9ed33ff6391ce82ce666e  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.876996&#43;03:00
+TIME DURATION: 54.203916ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+            
+          
+        </div>
+        
+          
+          
+            
+              <h2>Content Management</h2>
+              <div class="subcategory">
+              
+              
+                <h3>Setup</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-55-button" class="toggle" onclick="javascript:toggleOutput('output-box-55')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-55')">Populate registry with test config blob</h4>
+                        <br>
+                        <div id="output-box-55" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.883950 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.883802&#43;03:00
+TIME DURATION: 6.074583ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.883976 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.887212 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.887045&#43;03:00
+TIME DURATION: 3.064584ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: d29c76b3-fb7d-4ae7-9c16-c604f12a042d
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/d29c76b3-fb7d-4ae7-9c16-c604f12a042d
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.888742 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/d29c76b3-fb7d-4ae7-9c16-c604f12a042d?digest=sha256%3A4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICI4RnFyM2dISGRmeE9jS2pLIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.888592&#43;03:00
+TIME DURATION: 1.341042ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.888772 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.896704 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/d29c76b3-fb7d-4ae7-9c16-c604f12a042d?digest=sha256%3A4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 129
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+ewoJImF1dGhvciI6ICI4RnFyM2dISGRmeE9jS2pLIiwKCSJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJInR5cGUiOiAibGF5ZXJzIiwKCQkiZGlmZl9pZHMiOiBbXQoJfQp9
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.896247&#43;03:00
+TIME DURATION: 7.467ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Content-Digest: sha256:4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-56-button" class="toggle" onclick="javascript:toggleOutput('output-box-56')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-56')">Populate registry with test layer</h4>
+                        <br>
+                        <div id="output-box-56" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.899488 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.899193&#43;03:00
+TIME DURATION: 2.380458ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.899550 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.903128 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+POST  /v2/docker-local/testimg/blobs/uploads/  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.90252&#43;03:00
+TIME DURATION: 2.962042ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	Docker-Upload-Uuid: cd208434-317f-419e-8563-d752dddad6fe
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/cd208434-317f-419e-8563-d752dddad6fe
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+2023/04/04 16:24:08.905368 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/cd208434-317f-419e-8563-d752dddad6fe?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.904706&#43;03:00
+TIME DURATION: 1.466292ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.905457 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.912617 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/blobs/uploads/cd208434-317f-419e-8563-d752dddad6fe?digest=sha256%3A48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	Content-Length: 168
+	Content-Type: application/octet-stream
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+H4sIAAAAAAAAA&#43;3OQQrCMBCF4a49xXgBSUnaHMCTRBptQRNpp6i3t0UEV7oqIv7fYgbmzeJpHHSjVy0WZCa1c/MufWVe94N3RWlrZ72x3k/30nhbFWKWLPU0Dhp6keJ8im//PuU/6pZH2WVtYx8b0Sz7LjWSR5VLG6YRBumSzOlGtjkd&#43;qDjMWiX07Befbs7AAAAAAAAAAAAAAAAAPyzO34MnqoAKAAA
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.912085&#43;03:00
+TIME DURATION: 6.604791ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Content-Digest: sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/sha256:48acff1d91752e957527c1b5416e7376d910bcacf01b9441175f8c270e35c183
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-57-button" class="toggle" onclick="javascript:toggleOutput('output-box-57')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-57')">Populate registry with test tag</h4>
+                        <br>
+                        <div id="output-box-57" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.914990 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjQ4NzhkNzE5NmZjYzRlODQyY2E3ODY4ODdmMTA2N2FmZGZlMjViN2EyMmY2OGZmMzI0OGViY2I5MWE5ZjY4YjgiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0k0Um5GeU0yZElTR1JtZUU5alMycExJaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.914416&#43;03:00
+TIME DURATION: 1.650833ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.915036 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.935214 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+PUT  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Accept: application/vnd.oci.image.manifest.v1&#43;json
+	Authorization: Basic *****
+	Content-Type: application/vnd.oci.image.manifest.v1&#43;json
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+&#34;ewoJInNjaGVtYVZlcnNpb24iOiAyLAoJImNvbmZpZyI6IHsKCQkibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuY29uZmlnLnYxK2pzb24iLAoJCSJkaWdlc3QiOiAic2hhMjU2OjQ4NzhkNzE5NmZjYzRlODQyY2E3ODY4ODdmMTA2N2FmZGZlMjViN2EyMmY2OGZmMzI0OGViY2I5MWE5ZjY4YjgiLAoJCSJzaXplIjogMTI5LAoJCSJkYXRhIjogImV3b0pJbUYxZEdodmNpSTZJQ0k0Um5GeU0yZElTR1JtZUU5alMycExJaXdLQ1NKaGNtTm9hWFJsWTNSMWNtVWlPaUFpWVcxa05qUWlMQW9KSW05eklqb2dJbXhwYm5WNElpd0tDU0p5YjI5MFpuTWlPaUI3Q2drSkluUjVjR1VpT2lBaWJHRjVaWEp6SWl3S0NRa2laR2xtWmw5cFpITWlPaUJiWFFvSmZRcDkiLAoJCSJuZXdVbnNwZWNpZmllZEZpZWxkIjogImFHVnNiRzhnZDI5eWJHUT0iCgl9LAoJImxheWVycyI6IFsKCQl7CgkJCSJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5sYXllci52MS50YXIrZ3ppcCIsCgkJCSJkaWdlc3QiOiAic2hhMjU2OjQ4YWNmZjFkOTE3NTJlOTU3NTI3YzFiNTQxNmU3Mzc2ZDkxMGJjYWNmMDFiOTQ0MTE3NWY4YzI3MGUzNWMxODMiLAoJCQkic2l6ZSI6IDE2OCwKCQkJImRhdGEiOiBudWxsLAoJCQkibmV3VW5zcGVjaWZpZWRGaWVsZCI6IG51bGwKCQl9CgldCn0=&#34;
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 201 Created
+RECEIVED AT  : 2023-04-04T16:24:08.934935&#43;03:00
+TIME DURATION: 19.869583ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Content-Digest: sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5
+	Docker-Distribution-Api-Version: registry/2.0
+	Location: http://10.7.22.71:8082/v2/docker-local/testimg/blobs/uploads/sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-58-button" class="toggle" onclick="javascript:toggleOutput('output-box-58')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-58')">Check how many tags there are before anything gets deleted</h4>
+                        <br>
+                        <div id="output-box-58" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.937364 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.93723&#43;03:00
+TIME DURATION: 1.960333ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.937385 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.943736 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.943162&#43;03:00
+TIME DURATION: 5.77475ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;emptylayer&#34;,
+      &#34;tagtest0&#34;
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Manifest delete</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-59-button" class="toggle" onclick="javascript:toggleOutput('output-box-59')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-59')">DELETE request to manifest tag should return 202, unless tag deletion is disallowed (400/405)</h4>
+                        <br>
+                        <div id="output-box-59" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.948923 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.948563&#43;03:00
+TIME DURATION: 4.689625ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.948977 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.962215 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/tagtest0  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 202 Accepted
+RECEIVED AT  : 2023-04-04T16:24:08.961844&#43;03:00
+TIME DURATION: 12.859042ms
+HEADERS      :
+	Content-Length: 0
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-60-button" class="toggle" onclick="javascript:toggleOutput('output-box-60')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-60')">DELETE request to manifest (digest) should yield 202 response unless already deleted</h4>
+                        <br>
+                        <div id="output-box-60" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.964997 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.964617&#43;03:00
+TIME DURATION: 2.168417ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.965053 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.969205 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/manifests/sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.968804&#43;03:00
+TIME DURATION: 3.741625ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;MANIFEST_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;The named manifest is not known to the registry.&#34;,
+         &#34;detail&#34;: {
+            &#34;manifest&#34;: &#34;sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-61-button" class="toggle" onclick="javascript:toggleOutput('output-box-61')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-61')">GET request to deleted manifest URL should yield 404 response, unless delete is disallowed</h4>
+                        <br>
+                        <div id="output-box-61" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.971232 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.971084&#43;03:00
+TIME DURATION: 1.823166ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.971258 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.975371 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/manifests/sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.974714&#43;03:00
+TIME DURATION: 3.453125ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;MANIFEST_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;The named manifest is not known to the registry.&#34;,
+         &#34;detail&#34;: {
+            &#34;manifest&#34;: &#34;sha256:cbba766f90981d5e15c137efd2acec2589b66915c0e102f6c349ca7890addcf5&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-62-button" class="toggle" onclick="javascript:toggleOutput('output-box-62')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-62')">GET request to tags list should reflect manifest deletion</h4>
+                        <br>
+                        <div id="output-box-62" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.977605 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.977321&#43;03:00
+TIME DURATION: 1.835666ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.977645 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.984380 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/tags/list  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 200 OK
+RECEIVED AT  : 2023-04-04T16:24:08.983884&#43;03:00
+TIME DURATION: 6.23275ms
+HEADERS      :
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;name&#34;: &#34;testimg&#34;,
+   &#34;tags&#34;: [
+      &#34;emptylayer&#34;
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+                <h3>Blob delete</h3>
+                
+                
+                  
+                  
+                    
+                    
+                      <div class="result red">
+                        <div id="output-box-63-button" class="toggle" onclick="javascript:toggleOutput('output-box-63')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-63')">DELETE request to blob URL should yield 202 response</h4>
+                        <br>
+                        <div>
+                          <div id="output-box-63" style="display: none;">
+                            <pre class="pre-box">2023/04/04 16:24:08.986364 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.986222&#43;03:00
+TIME DURATION: 1.759708ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.986388 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.988647 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+DELETE  /v2/docker-local/testimg/blobs/sha256:4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 405 Method Not Allowed
+RECEIVED AT  : 2023-04-04T16:24:08.988173&#43;03:00
+TIME DURATION: 1.781667ms
+HEADERS      :
+	Allow: HEAD,GET,OPTIONS
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 405,
+         &#34;message&#34;: &#34;Method Not Allowed&#34;
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                          </div>
+                        </div>
+                        <pre class="fail-message">Expected
+    &lt;int&gt;: 405
+to equal
+    &lt;int&gt;: 202</pre>
+                        <br>
+                      </div>
+                    
+                  
+                    
+                    
+                      <div class="result green">
+                        <div id="output-box-64-button" class="toggle" onclick="javascript:toggleOutput('output-box-64')">+</div>
+                        <h4 style="display: inline;" onclick="javascript:toggleOutput('output-box-64')">GET request to deleted blob URL should yield 404 response</h4>
+                        <br>
+                        <div id="output-box-64" style="display: none;">
+                          <pre class="pre-box">2023/04/04 16:24:08.990751 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 401 Unauthorized
+RECEIVED AT  : 2023-04-04T16:24:08.990444&#43;03:00
+TIME DURATION: 1.538375ms
+HEADERS      :
+	Content-Length: 91
+	Content-Type: application/json;charset=ISO-8859-1
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Www-Authenticate: Basic realm=&#34;Artifactory Realm&#34;
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;status&#34;: 401,
+         &#34;message&#34;: &#34;Authentication is required&#34;
+      }
+   ]
+}
+==============================================================================
+
+2023/04/04 16:24:08.990802 WARN Using Basic Auth in HTTP mode is not secure, use HTTPS
+
+2023/04/04 16:24:08.994255 DEBUG 
+==============================================================================
+~~~ REQUEST ~~~
+GET  /v2/docker-local/testimg/blobs/sha256:4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8  HTTP/1.1
+HOST   : 10.7.22.71:8082
+HEADERS:
+	Authorization: Basic *****
+	User-Agent: distribution-spec-conformance-tests
+BODY   :
+***** NO CONTENT *****
+------------------------------------------------------------------------------
+~~~ RESPONSE ~~~
+STATUS       : 404 Not Found
+RECEIVED AT  : 2023-04-04T16:24:08.993763&#43;03:00
+TIME DURATION: 2.952292ms
+HEADERS      :
+	Content-Length: 168
+	Content-Type: application/json
+	Date: Tue, 04 Apr 2023 13:24:08 GMT
+	Docker-Distribution-Api-Version: registry/2.0
+	X-Artifactory-Id: ed24007b793c200f:-411bfa8b:1874c5fddbe:-8000
+	X-Artifactory-Node-Id: 75204189-f208-4747-9937-ca0e5905e81a
+	X-Jfrog-Version: Artifactory/development 2147483647
+BODY         :
+{
+   &#34;errors&#34;: [
+      {
+         &#34;code&#34;: &#34;BLOB_UNKNOWN&#34;,
+         &#34;message&#34;: &#34;blob unknown to registry&#34;,
+         &#34;detail&#34;: {
+            &#34;blobSum&#34;: &#34;sha256:4878d7196fcc4e842ca786887f1067afdfe25b7a22f68ff3248ebcb91a9f68b8&#34;
+         }
+      }
+   ]
+}
+==============================================================================
+
+</pre>
+                        </div>
+                      </div>
+                    
+                  <br>
+                
+              
+            
+          
+        </div>
+        
+      
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds the conformance results for jFrog Artifactory.

Please note, 
Artifactory is handling the deletion of the blobs.
Hence we don't expose this API.
That's explain the failures on the report.

Referring your [spec.md#Content Management
](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#content-management)

> "Content management refers to the deletion of blobs, tags, and manifests. Registries MAY implement deletion or they MAY disable it. Similarly, a registry MAY implement tag deletion, while others MAY allow deletion only by manifest."

Signed-off-by: AiSofer [idanso@jfrog.com](mailto:idanso@jfrog.com)
